### PR TITLE
Allow using (opt in) localStorage instead of sessionStorage (for some mobile flows)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 /dist
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -60,3 +60,18 @@ pkce.exchangeForAccessToken(url, additionalParams).then((resp) => {
   // Do stuff with the access token.
 });
 ```
+
+## A note on Storage
+By default, this package will use `sessionStorage` to persist the `pkce_state`. On (mostly) mobile
+devices there's a higher chance users are returning in a different browser tab. E.g. they kick off
+in a WebView & get redirected to a new tab. The `sessionStorage` will be empty there.
+
+In this case it you can opt in to use `localStorage` instead of `sessionStorage`:
+
+```javascript
+import PKCE from 'js-pkce';
+const pkce = new PKCE({
+  // ...
+  storage_type: 'localStorage', // sessionStorage (default) or localStorage 
+});
+```

--- a/README.md
+++ b/README.md
@@ -72,6 +72,6 @@ In this case it you can opt in to use `localStorage` instead of `sessionStorage`
 import PKCE from 'js-pkce';
 const pkce = new PKCE({
   // ...
-  storage_type: 'localStorage', // sessionStorage (default) or localStorage 
+  storage: localStorage, // any Storage object, sessionStorage (default) or localStorage 
 });
 ```

--- a/src/IConfig.d.ts
+++ b/src/IConfig.d.ts
@@ -4,4 +4,5 @@ export default interface IConfig {
   authorization_endpoint: string;
   token_endpoint: string;
   requested_scopes: string;
+  storage_type?: string;
 }

--- a/src/IConfig.d.ts
+++ b/src/IConfig.d.ts
@@ -4,5 +4,5 @@ export default interface IConfig {
   authorization_endpoint: string;
   token_endpoint: string;
   requested_scopes: string;
-  storage_type?: string;
+  storage?: Storage;
 }

--- a/src/PKCE.ts
+++ b/src/PKCE.ts
@@ -95,7 +95,7 @@ export default class PKCE {
     const stateKey = 'pkce_state';
 
     if (explicit !== null) {
-      sessionStorage.setItem(stateKey, explicit);
+      this.getStore().setItem(stateKey, explicit);
     }
 
     if (this.state === '') {
@@ -136,12 +136,12 @@ export default class PKCE {
    * @return {string}
    */
   private randomStringFromStorage(key: string): string {
-    const fromStorage = sessionStorage.getItem(key);
+    const fromStorage = this.getStore().getItem(key);
     if (fromStorage === null) {
-      sessionStorage.setItem(key, WordArray.random(64));
+      this.getStore().setItem(key, WordArray.random(64));
     }
 
-    return sessionStorage.getItem(key) || '';
+    return this.getStore().getItem(key) || '';
   }
 
   /**
@@ -161,5 +161,13 @@ export default class PKCE {
 
       return resolve(queryParams);
     });
+  }
+
+  /**
+   * Get the storage (sessionStorage / localStorage) to use, defaults to sessionStorage
+   * @return {Storage}
+   */
+  private getStore(): Storage {
+    return globalThis[this.config?.storage_type || 'sessionStorage'];
   }
 }

--- a/src/PKCE.ts
+++ b/src/PKCE.ts
@@ -168,6 +168,6 @@ export default class PKCE {
    * @return {Storage}
    */
   private getStore(): Storage {
-    return globalThis[this.config?.storage_type || 'sessionStorage'];
+    return this.config?.storage || sessionStorage
   }
 }

--- a/tests/PKCE.test.ts
+++ b/tests/PKCE.test.ts
@@ -6,7 +6,7 @@ const config = {
   redirect_uri: 'http://localhost:8080/',
   authorization_endpoint: 'https://example.com/auth',
   token_endpoint: 'https://example.com/token',
-  requested_scopes: "*"
+  requested_scopes: '*',
 };
 
 describe('Test PKCE authorization url', () => {
@@ -134,4 +134,28 @@ describe('Test PKCE exchange code for token', () => {
 
     await instance.exchangeForAccessToken(url, additionalParams);
   }
+});
+
+describe('Test storage types', () => {
+  it('Should default to sessionStorage, localStorage emtpy', async () => {
+    sessionStorage.removeItem('pkce_code_verifier');
+    localStorage.removeItem('pkce_code_verifier');
+
+    const instance = new PKCE({ ...config });
+    instance.authorizeUrl();
+
+    expect(sessionStorage.getItem('pkce_code_verifier')).not.toEqual(null);
+    expect(localStorage.getItem('pkce_code_verifier')).toEqual(null);    
+  });
+
+  it('Should allow for using localStorage, sessionStorage emtpy', async () => {
+    sessionStorage.removeItem('pkce_code_verifier');
+    localStorage.removeItem('pkce_code_verifier');
+
+    const instance = new PKCE({ ...config, storage_type: 'localStorage' });
+    instance.authorizeUrl();
+
+    expect(sessionStorage.getItem('pkce_code_verifier')).toEqual(null);
+    expect(localStorage.getItem('pkce_code_verifier')).not.toEqual(null);
+  });
 });

--- a/tests/PKCE.test.ts
+++ b/tests/PKCE.test.ts
@@ -152,7 +152,7 @@ describe('Test storage types', () => {
     sessionStorage.removeItem('pkce_code_verifier');
     localStorage.removeItem('pkce_code_verifier');
 
-    const instance = new PKCE({ ...config, storage_type: 'localStorage' });
+    const instance = new PKCE({ ...config, storage: localStorage });
     instance.authorizeUrl();
 
     expect(sessionStorage.getItem('pkce_code_verifier')).toEqual(null);


### PR DESCRIPTION
By default, this package will use `sessionStorage` to persist the `pkce_state`. On (mostly) mobile
devices there's a higher chance users are returning in a different browser tab. E.g. they kick off
in a WebView & get redirected to a new tab. The `sessionStorage` will be empty there.

In this case it you can opt in to use `localStorage` instead of `sessionStorage`:

```javascript
import PKCE from 'js-pkce';
const pkce = new PKCE({
  // ...
  storage: localStorage, // any Storage object, e.g. sessionStorage (default) or localStorage 
});
```

-- And: thanks for this lib @bpedroza :)