### PR TITLE
fix: updates 'refresh_token' and 'refresh_expires_in' to be optional properties on the ITokenResponse

### DIFF
--- a/src/ITokenResponse.ts
+++ b/src/ITokenResponse.ts
@@ -1,8 +1,8 @@
 export default interface ITokenResponse {
   access_token: string;
   expires_in: number;
-  refresh_expires_in: number;
-  refresh_token: string;
+  refresh_expires_in?: number;
+  refresh_token?: string;
   scope: string;
   token_type: string;
 }


### PR DESCRIPTION
From my understanding the `refresh_token` won't always be available on the token response. The actual implementation is dictated by the authorization server, but most often will only be included if explicitly requested by scope (i.e., `offline_access`).

```
 refresh_token
         OPTIONAL.  The refresh token, which can be used to obtain new
         access tokens using the same authorization grant as described
         in Section 6.
```

https://datatracker.ietf.org/doc/html/rfc6749#section-5.1
https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/


I could see this type change being problematic for downstream consumers (and also implemented using a union of more well-defined types rather than optional properties), but figured I'd open this up for discussion.

Thanks for your work on this library!