### PR TITLE
Specify revoke token return type and test for failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "js-pkce",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/PKCE.ts
+++ b/src/PKCE.ts
@@ -113,7 +113,7 @@ export default class PKCE {
     }).then((response) => response.json());
   }
 
-  public revokeToken(tokenToExpire: string, hint: string = '') {
+  public revokeToken(tokenToExpire: string, hint: string = ''): Promise<boolean> {
     this.checkEndpoint('revoke_endpoint');
     const params = new URLSearchParams({
       token: tokenToExpire,
@@ -128,7 +128,8 @@ export default class PKCE {
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
       },
-    }).then((response) => response.json());
+    }).then((response) => response.ok)
+    .catch(() => false);
   }
 
   private checkEndpoint(propertyName: string) {

--- a/tests/PKCE.test.ts
+++ b/tests/PKCE.test.ts
@@ -216,10 +216,24 @@ describe('Test PCKE revoke token', () => {
 
   it('Should make a request to revoke token endpoint', async () => {
     const url = 'https://example.com/revoke';
-    await mockRequest({revoke_endpoint: url});
+    const ok = await mockRequest({revoke_endpoint: url});
 
+    expect(ok).toEqual(true);
     expect(fetch.mock.calls.length).toEqual(1);
     expect(fetch.mock.calls[0][0]).toEqual(url);
+  });
+
+  it('Should return false on error response', async () => {
+    const instance = new PKCE({
+      ...config,
+      revoke_endpoint: 'https://example.com/revoke'
+    });
+
+    fetch.resetMocks();
+    fetch.mockReject(new Error('fake error message'))
+    const ok = await instance.revokeToken('atoken');
+
+    expect(ok).toEqual(false);
   });
 
   it('Should request with headers', async () => {


### PR DESCRIPTION
The revoke token method was not specifying a return type, and was simply returning the response. This behavior was not consistent, and failed to conform to the specification. Method now returns a boolean. 

I am aware this may be considered breaking, but the return type was not specified before, so could not be relied upon anyways.